### PR TITLE
Parse html with langchain-beautifulsoup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.12.3
 langchain-openai==0.1.3
 Scrapy>=2.11.1, <2.12.0
+langchain==0.1.16

--- a/src/parseHTML.py
+++ b/src/parseHTML.py
@@ -1,0 +1,38 @@
+
+import config
+from pathlib import Path
+from langchain_community.document_transformers import BeautifulSoupTransformer
+from langchain.docstore.document import Document
+
+def parse_HTML():
+    """Parse the data collected by the crawler"""
+
+    crawler_dir: Path = Path(config.DATA_PATH).joinpath("crawler_data")
+    parsed_dir = crawler_dir.parent.joinpath("parsed_data")
+    parsed_dir.mkdir(parents=True, exist_ok=True)
+
+    for file in parsed_dir.iterdir():
+        file.unlink()
+
+    bs4_transformer = BeautifulSoupTransformer()
+    exclude = ["style", "script", "head", "title", "meta", "[document]"]
+    include = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "a", "ul", "ol", "li", "div", "span"]
+    document = []
+ 
+    for file in crawler_dir.iterdir():
+        if file.is_dir():
+            continue
+
+        with open(file, "r", encoding="utf-8", errors="ignore") as f:
+            data = f.read()
+            doc =  Document(page_content=data, metadata={"source": "local"})
+            document.append(doc)
+
+    docs_transformed = bs4_transformer.transform_documents(document, unwanted_tags=exclude, tags_to_extract=include, remove_comments=True, remove_lines=False)
+
+    for idx, file in enumerate(crawler_dir.iterdir()):
+        if file.is_dir():
+            continue
+        
+        with open(f"{parsed_dir.joinpath(file.with_suffix('.md').name)}", "w", encoding="utf-8", errors="ignore") as f:
+            f.write(docs_transformed[idx].page_content)

--- a/src/processing.py
+++ b/src/processing.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import subprocess
 import platform
 from api.yellowpages.yellowpages import YellowpagesAPI
+from langchain_community.document_transformers import BeautifulSoupTransformer
+from langchain.docstore.document import Document
 
 
 def run_crawler(urls: list[str], max_depth: int):
@@ -24,6 +26,39 @@ def run_crawler(urls: list[str], max_depth: int):
         case _:
             print("OS not supported")
 
+def parse_data():
+    """Parse the data collected by the crawler"""
+
+    crawler_dir: Path = Path(config.DATA_PATH).joinpath("crawler_data")
+    parsed_dir = crawler_dir.parent.joinpath("parsed_data")
+    parsed_dir.mkdir(parents=True, exist_ok=True)
+
+    for file in parsed_dir.iterdir():
+        file.unlink()
+
+    bs4_transformer = BeautifulSoupTransformer()
+    exclude = ["style", "script", "head", "title", "meta", "[document]"]
+    include = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "a", "ul", "ol", "li", "div", "span"]
+    document = []
+ 
+    for file in crawler_dir.iterdir():
+        if file.is_dir():
+            continue
+
+        with open(file, "r", encoding="utf-8", errors="ignore") as f:
+            data = f.read()
+            doc =  Document(page_content=data, metadata={"source": "local"})
+            document.append(doc)
+
+    docs_transformed = bs4_transformer.transform_documents(document, unwanted_tags=exclude, tags_to_extract=include, remove_comments=True, remove_lines=False)
+
+    for idx, file in enumerate(crawler_dir.iterdir()):
+        if file.is_dir():
+            continue
+        
+        with open(f"{parsed_dir.joinpath(file.with_suffix('.md').name)}", "w", encoding="utf-8", errors="ignore") as f:
+            f.write(docs_transformed[idx].page_content)
+
 
 if __name__ == "__main__":
     config.init_paths()
@@ -36,6 +71,8 @@ if __name__ == "__main__":
 
     run_crawler(["https://uit.no/research/csg?p_document_id=837262&Baseurl=%2Fresearch%2F"], 2)
     run_crawler(["https://uit.no/startsida"], 1)
+
+    parse_data()
 
 
     # yellow = YellowpagesAPI()

--- a/src/processing.py
+++ b/src/processing.py
@@ -6,8 +6,7 @@ from pathlib import Path
 import subprocess
 import platform
 from api.yellowpages.yellowpages import YellowpagesAPI
-from langchain_community.document_transformers import BeautifulSoupTransformer
-from langchain.docstore.document import Document
+from parseHTML import parse_HTML
 
 
 def run_crawler(urls: list[str], max_depth: int):
@@ -26,39 +25,6 @@ def run_crawler(urls: list[str], max_depth: int):
         case _:
             print("OS not supported")
 
-def parse_data():
-    """Parse the data collected by the crawler"""
-
-    crawler_dir: Path = Path(config.DATA_PATH).joinpath("crawler_data")
-    parsed_dir = crawler_dir.parent.joinpath("parsed_data")
-    parsed_dir.mkdir(parents=True, exist_ok=True)
-
-    for file in parsed_dir.iterdir():
-        file.unlink()
-
-    bs4_transformer = BeautifulSoupTransformer()
-    exclude = ["style", "script", "head", "title", "meta", "[document]"]
-    include = ["p", "h1", "h2", "h3", "h4", "h5", "h6", "a", "ul", "ol", "li", "div", "span"]
-    document = []
- 
-    for file in crawler_dir.iterdir():
-        if file.is_dir():
-            continue
-
-        with open(file, "r", encoding="utf-8", errors="ignore") as f:
-            data = f.read()
-            doc =  Document(page_content=data, metadata={"source": "local"})
-            document.append(doc)
-
-    docs_transformed = bs4_transformer.transform_documents(document, unwanted_tags=exclude, tags_to_extract=include, remove_comments=True, remove_lines=False)
-
-    for idx, file in enumerate(crawler_dir.iterdir()):
-        if file.is_dir():
-            continue
-        
-        with open(f"{parsed_dir.joinpath(file.with_suffix('.md').name)}", "w", encoding="utf-8", errors="ignore") as f:
-            f.write(docs_transformed[idx].page_content)
-
 
 if __name__ == "__main__":
     config.init_paths()
@@ -72,7 +38,7 @@ if __name__ == "__main__":
     run_crawler(["https://uit.no/research/csg?p_document_id=837262&Baseurl=%2Fresearch%2F"], 2)
     run_crawler(["https://uit.no/startsida"], 1)
 
-    parse_data()
+    parse_HTML()
 
 
     # yellow = YellowpagesAPI()


### PR DESCRIPTION
Uses langchain beautifulsoup transformer to parse HTML files.
Can specify which tags to exclude and include when parsing.
Writes parsed data to disk in md-format.